### PR TITLE
feat: Completed API to save document OCR coordinates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,12 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
     // ⭐ AWS
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    // ⭐ MapStruct
+    annotationProcessor("org.mapstruct:mapstruct-processor:1.5.3.Final")
+    testAnnotationProcessor("org.mapstruct:mapstruct-processor:1.5.3.Final")
+    implementation("org.mapstruct:mapstruct:1.5.3.Final")
+    implementation("org.projectlombok:lombok-mapstruct-binding:0.2.0")
+
 }
 
 tasks.named('test') {

--- a/src/main/java/sesac/docshelper/domain/docs/controller/DocsController.java
+++ b/src/main/java/sesac/docshelper/domain/docs/controller/DocsController.java
@@ -1,0 +1,24 @@
+package sesac.docshelper.domain.docs.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sesac.docshelper.domain.docs.dto.ItemInfoDTO;
+import sesac.docshelper.domain.docs.dto.request.SettingCoordinateRequest;
+import sesac.docshelper.domain.docs.service.CoordinateService;
+import sesac.docshelper.global.dto.response.ResultResponse;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/docs")
+@RequiredArgsConstructor
+public class DocsController {
+
+    private final CoordinateService coordinateService;
+
+    @PostMapping
+    public ResponseEntity<ResultResponse<String>> setCoordinates4Docs(@RequestBody SettingCoordinateRequest request) {
+        return ResponseEntity.ok(ResultResponse.success(coordinateService.saveDocumentCoordinate(request.items(), request.title(), request.isBlank()))); // 성공이라는 200 code와 함께 매개 변수로 받은 값을 전달
+    }
+}

--- a/src/main/java/sesac/docshelper/domain/docs/dto/DocsInfoDTO.java
+++ b/src/main/java/sesac/docshelper/domain/docs/dto/DocsInfoDTO.java
@@ -6,7 +6,8 @@ import java.util.List;
 
 public record DocsInfoDTO(
         String title, //서류 제목
-        MultipartFile image, //원본 서류 이미지
-        List<ItemInfoDTO> items //빈칸 정보
+        String image, //원본 서류 이미지
+        List<ItemInfoDTO> items, //내용 있는 칸 좌표
+        List<ItemInfoDTO> emptyItems // 빈칸 좌표
 ) {
 }

--- a/src/main/java/sesac/docshelper/domain/docs/dto/request/SettingCoordinateRequest.java
+++ b/src/main/java/sesac/docshelper/domain/docs/dto/request/SettingCoordinateRequest.java
@@ -1,0 +1,16 @@
+package sesac.docshelper.domain.docs.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Service;
+import sesac.docshelper.domain.docs.dto.ItemInfoDTO;
+
+import java.util.List;
+
+
+public record SettingCoordinateRequest (
+        List<ItemInfoDTO> items,
+        String title,
+        boolean isBlank
+) {
+}

--- a/src/main/java/sesac/docshelper/domain/docs/entity/Coordinate.java
+++ b/src/main/java/sesac/docshelper/domain/docs/entity/Coordinate.java
@@ -1,0 +1,30 @@
+package sesac.docshelper.domain.docs.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Coordinate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    @Enumerated(EnumType.STRING)
+    private DocsType docsType;  // 어떤 서류에 대한 좌표인지
+    private boolean isBlank;    // 빈칸 좌표인지 질문의 좌표인지
+    // 실제 값
+    private String columnName;  // 컬럼명
+    private double top;         // 상단 좌표
+    @Column(name = "`left`")    // 예약어네...
+    private double left;        // 좌측 좌표 -> top과 합치면 좌상단
+    private double width;       // 넓이
+    private double height;      // 높이
+    @ColumnDefault("false")
+    private boolean isCheck;      // check를 위한 공란인가 아닌가
+}

--- a/src/main/java/sesac/docshelper/domain/docs/entity/DocsType.java
+++ b/src/main/java/sesac/docshelper/domain/docs/entity/DocsType.java
@@ -1,0 +1,6 @@
+package sesac.docshelper.domain.docs.entity;
+
+public enum DocsType {
+    TEST_DOCS, IDENTITY_CARD, PASSPORT;
+
+}

--- a/src/main/java/sesac/docshelper/domain/docs/mapper/DocsMapper.java
+++ b/src/main/java/sesac/docshelper/domain/docs/mapper/DocsMapper.java
@@ -1,0 +1,34 @@
+package sesac.docshelper.domain.docs.mapper;
+
+import org.mapstruct.*;
+import sesac.docshelper.domain.docs.dto.ItemInfoDTO;
+import sesac.docshelper.domain.docs.entity.Coordinate;
+import sesac.docshelper.domain.docs.entity.DocsType;
+
+import java.util.List;
+import java.util.StringTokenizer;
+
+@Mapper(componentModel = "spring", unmappedSourcePolicy = ReportingPolicy.IGNORE)
+public interface DocsMapper {
+    @Named("dtoToEntity")
+    @Mapping(target = "docsType", expression = "java(sesac.docshelper.domain.docs.entity.DocsType.valueOf(title))")
+    @Mapping(target = "blank", source = "isBlank")
+    @Mapping(target = "columnName", source = "item.columnName")
+    @Mapping(target = "top", source = "item.top")
+    @Mapping(target = "left", source = "item.left")
+    @Mapping(target = "width", source = "item.width")
+    @Mapping(target = "height", source = "item.height")
+    @Mapping(target = "check", ignore = true) // check 필드를 이후에 설정
+    Coordinate dtoToCoordinate (ItemInfoDTO item, String title, boolean isBlank);
+
+    @AfterMapping
+    default void setCheck(@MappingTarget Coordinate coordinate, ItemInfoDTO item) {
+        StringTokenizer st = new StringTokenizer(item.columnName());
+        String lastToken = "";
+        while (st.hasMoreTokens()){
+            lastToken = st.nextToken();
+        }
+        coordinate.setCheck("check".equalsIgnoreCase(lastToken));
+    }
+}
+

--- a/src/main/java/sesac/docshelper/domain/docs/repository/CoordinateRepository.java
+++ b/src/main/java/sesac/docshelper/domain/docs/repository/CoordinateRepository.java
@@ -1,0 +1,13 @@
+package sesac.docshelper.domain.docs.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sesac.docshelper.domain.docs.entity.Coordinate;
+import sesac.docshelper.domain.docs.entity.DocsType;
+
+
+public interface CoordinateRepository extends JpaRepository<Coordinate, Long> {
+
+    boolean existsByDocsType(DocsType docsType);
+    void deleteAllByDocsType(DocsType docsType);
+
+}

--- a/src/main/java/sesac/docshelper/domain/docs/service/CoordinateService.java
+++ b/src/main/java/sesac/docshelper/domain/docs/service/CoordinateService.java
@@ -1,0 +1,44 @@
+package sesac.docshelper.domain.docs.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sesac.docshelper.domain.docs.dto.ItemInfoDTO;
+import sesac.docshelper.domain.docs.entity.DocsType;
+import sesac.docshelper.domain.docs.mapper.DocsMapper;
+import sesac.docshelper.domain.docs.repository.CoordinateRepository;
+import sesac.docshelper.global.exception.ErrorCode;
+import sesac.docshelper.global.exception.GlobalException;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CoordinateService {
+
+    private final CoordinateRepository coordinateRepository;
+    private final DocsMapper docsMapper;
+
+    @Transactional
+    public String saveDocumentCoordinate(List<ItemInfoDTO> items, String title, boolean isBlank) {
+        try{
+            if(coordinateRepository.existsByDocsType(DocsType.valueOf(title))){
+                coordinateRepository.deleteAllByDocsType(DocsType.valueOf(title));
+            }
+            coordinateRepository.saveAll(items.stream()
+                    .map(item -> docsMapper.dtoToCoordinate(item,title,isBlank))
+                    .toList());
+        }catch (IllegalArgumentException e) {
+            log.info(e.getMessage());
+            throw new GlobalException(ErrorCode.VALID_DOCS_TYPE);
+        } catch (Exception e){
+            log.info(e.getMessage());
+            throw new GlobalException(ErrorCode.BAD_REQUET_TO_DOCS);
+        }
+
+        return "좌표들을 성공적으로 저장 하였습니다.";
+    }
+
+}

--- a/src/main/java/sesac/docshelper/domain/member/controller/MemberOauth2Controller.java
+++ b/src/main/java/sesac/docshelper/domain/member/controller/MemberOauth2Controller.java
@@ -19,7 +19,7 @@ import java.util.Map;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/members/")
+@RequestMapping("/members")
 public class MemberOauth2Controller {
     private final MemberOAuth2Service memberOAuth2Service;
 

--- a/src/main/java/sesac/docshelper/domain/member/dto/MemberInfoDTO.java
+++ b/src/main/java/sesac/docshelper/domain/member/dto/MemberInfoDTO.java
@@ -3,6 +3,7 @@ package sesac.docshelper.domain.member.dto;
 public record MemberInfoDTO(
         String email,
         String name,
+        String profileImage,
         PassportInfoDTO passportInfo,
         IdentityCardInfoDTO identityCardInfo,
         Long income, //소득

--- a/src/main/java/sesac/docshelper/domain/member/dto/request/Items.java
+++ b/src/main/java/sesac/docshelper/domain/member/dto/request/Items.java
@@ -1,0 +1,4 @@
+package sesac.docshelper.domain.member.dto.request;
+
+public class Items {
+}

--- a/src/main/java/sesac/docshelper/domain/member/entity/IdentityCard.java
+++ b/src/main/java/sesac/docshelper/domain/member/entity/IdentityCard.java
@@ -16,4 +16,7 @@ public class IdentityCard {
     String endDateOfStay; //체류기간 만료일
     String address; //체류지
     String reportDate; //신고일
+
+    @OneToOne
+    Member member;
 }

--- a/src/main/java/sesac/docshelper/domain/member/entity/Member.java
+++ b/src/main/java/sesac/docshelper/domain/member/entity/Member.java
@@ -1,9 +1,6 @@
 package sesac.docshelper.domain.member.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,19 +16,19 @@ public class Member {
     long id;
     String email;
     String name;
-
     //추가 정보
-    Long passportId; //여권 id
-    Long identityCardId; //외국인등록증 id
     Long income; //소득
     String housingType; //주거형태
+    // 매핑
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
+    private IdentityCard identityCard;
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
+    private Passport passport;
 
     @Builder
-    public Member(String email, String name, long passportId, long identityCardId, long income, String housingType){
+    public Member(String email, String name, long income, String housingType){
         this.email = email;
         this.name  = name;
-        this.passportId = passportId;
-        this.identityCardId = identityCardId;
         this.income =income;
         this.housingType = housingType;
     }
@@ -40,8 +37,6 @@ public class Member {
         return Member.builder()
                 .email(email)
                 .name(name)
-                .passportId(0)
-                .identityCardId(0)
                 .income(0)
                 .housingType(null)
                 .build();

--- a/src/main/java/sesac/docshelper/domain/member/entity/Passport.java
+++ b/src/main/java/sesac/docshelper/domain/member/entity/Passport.java
@@ -1,9 +1,6 @@
 package sesac.docshelper.domain.member.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 
 @Entity
 public class Passport {
@@ -22,4 +19,7 @@ public class Passport {
     String placeOfBirth; //출생지
     String type; //여권종류
     String countryOfIssue; //여권 발급국
+
+    @OneToOne
+    Member member;
 }

--- a/src/main/java/sesac/docshelper/domain/member/service/MemberOAuth2Service.java
+++ b/src/main/java/sesac/docshelper/domain/member/service/MemberOAuth2Service.java
@@ -18,6 +18,8 @@ import sesac.docshelper.domain.member.dto.response.SignUpResponse;
 import sesac.docshelper.domain.member.entity.Member;
 import sesac.docshelper.domain.member.repository.MemberRepository;
 import sesac.docshelper.global.dto.response.ResultResponse;
+import sesac.docshelper.global.exception.ErrorCode;
+import sesac.docshelper.global.exception.GlobalException;
 import sesac.docshelper.global.util.jwt.JwtUtil;
 
 import java.net.URLDecoder;
@@ -64,12 +66,18 @@ public class MemberOAuth2Service {
         // 요청에 대한 Entity 만들기
         HttpEntity<MultiValueMap<String,String>> requestEntity = new HttpEntity<>(params, headers);
         // AccessToken 요청 후 결과값 받기
-        ResponseEntity<String> responseEntity = new RestTemplate().exchange(
-                "https://oauth2.googleapis.com/token",
-                HttpMethod.POST,
-                requestEntity,
-                String.class
-        );
+        ResponseEntity<String> responseEntity;
+        try{
+            responseEntity = new RestTemplate().exchange(
+                    "https://oauth2.googleapis.com/token",
+                    HttpMethod.POST,
+                    requestEntity,
+                    String.class
+            );
+        } catch (Exception e){
+            log.error("google ATK 얻으려다 난 에러: {} -------------------------",e.getMessage());
+            throw new GlobalException(ErrorCode.BAD_REQUEST_TO_GOOGLE);
+        }
         // 받은 직렬화된 JSON 데이터를 역직렬화(객체화) 하기 위해 ObjectMapper를 사용.
         // ObjectMapper의 정책 설정: JSON에는 존재하지만, Java 객체에는 존재하지 않는 속성에 대해 무시하고 역직렬화 진행 (원래는 에러남)
         try{

--- a/src/main/java/sesac/docshelper/global/config/WebConfig.java
+++ b/src/main/java/sesac/docshelper/global/config/WebConfig.java
@@ -1,0 +1,22 @@
+package sesac.docshelper.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import sesac.docshelper.global.exception.RequestBodyInterceptor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+
+    private final RequestBodyInterceptor requestBodyInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+//        registry.addInterceptor(requestBodyInterceptor);
+    }
+}
+

--- a/src/main/java/sesac/docshelper/global/exception/ErrorCode.java
+++ b/src/main/java/sesac/docshelper/global/exception/ErrorCode.java
@@ -11,9 +11,13 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "멤버가 존재하지 않습니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰 입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 입니다."),
-
+    // Google
+    BAD_REQUEST_TO_GOOGLE(HttpStatus.BAD_REQUEST, "Redirect_type_misMatch"),
     // S3
-    CANT_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "해당 파일을 업로드할 수가 없습니다.")
+    CANT_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "해당 파일을 업로드할 수가 없습니다."),
+    // docs
+    VALID_DOCS_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 서류 유형입니다."),
+    BAD_REQUET_TO_DOCS(HttpStatus.BAD_REQUEST, "서류 추가 요청이 잘못되었습니다.")
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/sesac/docshelper/global/exception/RequestBodyInterceptor.java
+++ b/src/main/java/sesac/docshelper/global/exception/RequestBodyInterceptor.java
@@ -1,0 +1,24 @@
+package sesac.docshelper.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+@Component
+public class RequestBodyInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        if ("POST".equalsIgnoreCase(request.getMethod()) && request.getRequestURI().contains("/api")) {
+            BufferedReader reader = request.getReader();
+            String requestBody = reader.lines().collect(Collectors.joining(System.lineSeparator()));
+            System.out.println("Request Body: " + requestBody);
+        }
+        return true;
+    }
+}
+


### PR DESCRIPTION
# 💡 Related Issue
>  If there is a related issue, write the issue number and link

- #2 

# 📝 Summary
> Describe what feature is implemented by this PR.

좌표를 DB에 저장, 다음은 API의 규칙이다.
1. 만약 같은 유형의 서류이면, 해당 서류의 기존 좌표를 전부 삭제한 후 새로 받는다.
2. 만약 서류의 유형이 DB에서 정한 서류 중에 없으면 저장하지 않고 BAD_REQUEST 알림을 낸다. 

# 💬 (Optional) Description

> Describe your changes in detail

# 🚧 How has this been tested?

> Please describe the tests that you ran to verify your changes.

